### PR TITLE
Updated permissions for subclasses to access members.

### DIFF
--- a/src/MicroOscSlip.h
+++ b/src/MicroOscSlip.h
@@ -11,7 +11,7 @@
 template <const size_t MICRO_OSC_IN_SIZE>
 class MicroOscSlip : public MicroOsc
 {
-
+protected:
   MicroSlip slip_;
   unsigned char input_buffer_[MICRO_OSC_IN_SIZE];
 

--- a/src/MicroOscUdp.h
+++ b/src/MicroOscUdp.h
@@ -13,13 +13,13 @@
 
 template <const size_t MICRO_OSC_IN_SIZE>
 class MicroOscUdp : public MicroOsc {
-
+protected:
     UDP* udp;
     unsigned char inputBuffer[MICRO_OSC_IN_SIZE];
     IPAddress destinationIp = INADDR_NONE;
     unsigned int destinationPort;
 
-    protected:
+protected:
 	virtual void beginMessage() {
     /*
     Serial.print("Begin UDP OSC IP: ");


### PR DESCRIPTION
In order to allow PqOsc class OscUdp to call its udp->begin() I needed access to the udp pointer which was private.

I made it (and other superclasses' member variables) protected instead of private, allowing more flexibility for developers. Of course, this also comes with responsibilities for devs, so a middle route would be to have certain members private and others protected if you believe the risks are too important.

Another approach would be to keep things private but provide protected or public access methods.